### PR TITLE
feat: Add basic Hugo list and single page layouts

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,18 @@
+<!-- layouts/_default/list.html -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{{ .Site.Title }}</title>
+    </head>
+    <body>
+        <h1>{{ .Site.Title }}</h1>
+        <h2>{{ .Title }}</h2>
+        <ul>
+            {{ range .Pages }}
+            <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+            {{ end }}
+        </ul>
+    </body>
+</html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,16 @@
+<!-- layouts/_default/single.html -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{{ .Title }} - {{ .Site.Title }}</title>
+    </head>
+    <body>
+        <article>
+            <h1>{{ .Title }}</h1>
+            {{ .Content }}
+        </article>
+        <p><a href="/">Back to home</a></p>
+    </body>
+</html>


### PR DESCRIPTION
This commit fixes Issue #1 for the foundational HTML templates required for Hugo to render content correctly.

- **`layouts/_default/list.html`**: Provides a default layout for list pages, including the home page and taxonomy pages. This resolves the `WARN: found no layout file for "html" for kind "home"` and `WARN: found no layout file for "html" for kind "taxonomy"` messages observed during `hugo serve`. The template includes basic HTML structure, site title, page title, and a loop to display links to child pages.

- **`layouts/_default/single.html`**: Establishes a default layout for individual content pages (e.g., blog posts). This template includes the page title, site title, and renders the main content (`.Content`), along with a simple "Back to home" link.

These templates provide minimal styling but ensure that Hugo can generate HTML output for all primary content types, enabling the site to be viewed in a browser without layout errors.